### PR TITLE
Update CI helm version to match cluster helm version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2019-03-18
+
+### Fixed
+
+* Travis CI helm version now matches version running on cluster
+
 ## [0.3.0] - 2019-03-17
 
 ### Changed

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -19,7 +19,7 @@ mkdir "${HOME}/.kube" && \
   --output "${HOME}/.kube/config"
 
 # install helm, helm-diff and helm-secrets
-curl -L -s https://storage.googleapis.com/kubernetes-helm/helm-v2.13.0-linux-amd64.tar.gz --output helm.tar.gz && \
+curl -L -s https://storage.googleapis.com/kubernetes-helm/helm-v2.12.3-linux-amd64.tar.gz --output helm.tar.gz && \
   tar -zxvf helm.tar.gz && \
   sudo mv linux-amd64/helm /usr/local/bin/helm && \
   helm init --client-only && \


### PR DESCRIPTION
### Fixed

* Travis CI helm version now matches version running on cluster